### PR TITLE
Drop todo enum

### DIFF
--- a/src/db/migrations/1554558476713-RemoveTodoFromWipChallenges.ts
+++ b/src/db/migrations/1554558476713-RemoveTodoFromWipChallenges.ts
@@ -1,0 +1,37 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RemoveTodoFromWipChallenges1554558476713 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "UPDATE wip_challenges SET status='DOING' WHERE status='TODO';"
+    );
+    await queryRunner.query(
+      "ALTER TYPE wip_challenges_status_enum RENAME TO status_enum_old;"
+    );
+    await queryRunner.query(
+      "CREATE TYPE wip_challenges_status_enum AS ENUM('DOING', 'DONE');"
+    );
+    await queryRunner.query(
+      "ALTER TABLE wip_challenges ALTER COLUMN status TYPE wip_challenges_status_enum USING wip_challenges.status:: text:: wip_challenges_status_enum;"
+    );
+    await queryRunner.query(
+      "DROP TYPE status_enum_old;"
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "ALTER TYPE wip_challenges_status_enum RENAME TO status_enum_old;"
+    );
+    await queryRunner.query(
+      "CREATE TYPE wip_challenges_status_enum AS ENUM('TODO', 'DOING', 'DONE');"
+    );
+    await queryRunner.query(
+      "ALTER TABLE wip_challenges ALTER COLUMN status TYPE wip_challenges_status_enum USING wip_challenges.status:: text:: wip_challenges_status_enum;"
+    );
+    await queryRunner.query(
+      "DROP TYPE status_enum_old;"
+    );
+  }
+}

--- a/src/entities/wip_challenge.ts
+++ b/src/entities/wip_challenge.ts
@@ -11,7 +11,6 @@ import {
 import Challenge from "./challenge";
 
 export enum ChallengeStatus {
-  TODO = "TODO",
   DOING = "DOING",
   DONE = "DONE",
 }

--- a/src/graphql/wip_challenges.ts
+++ b/src/graphql/wip_challenges.ts
@@ -3,7 +3,6 @@ import WipChallenge, { ChallengeStatus } from "../entities/wip_challenge";
 
 const typeDefs = `
 enum ChallengeStatus {
-  TODO
   DOING
   DONE
 }
@@ -41,7 +40,7 @@ const resolvers = {
       return WipChallenge.create({
         userEmail,
         challengeId,
-        status: ChallengeStatus.TODO,
+        status: ChallengeStatus.DOING,
       }).save();
     },
     moveWipChallenge: async (obj: any, { id, newStatus }: { id: string; newStatus: ChallengeStatus }) => {


### PR DESCRIPTION
Dropping the initial `TODO` status since when a WipChallenge is created, it already has a `DOING` status 